### PR TITLE
Remove redundant wheel dep from pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ need to be committed to the SCM repo.
 Your `pyproject.toml` should also include `setuptools-declarative-requirements`:
 ```toml
 [build-system]
-requires = ["setuptools>=50.3.2", "wheel", "setuptools-declarative-requirements"]
+requires = ["setuptools>=50.3.2", "setuptools-declarative-requirements"]
 build-backend = "setuptools.build_meta"
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=50.3.2", "wheel", "setuptools_scm[toml]>=3.4"]
+requires = ["setuptools>=50.3.2", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -259,7 +259,6 @@ class Project:
         [build-system]
         requires = [
             "setuptools>=42",
-            "wheel",
             "setuptools_declarative_requirements=={__version__}"
         ]
         build-backend = "setuptools.build_meta"
@@ -325,7 +324,7 @@ def build_test_pkgs(tmp_path_factory, local_pypi_repo_path):
     pyproject_toml = textwrap.dedent(
         """\
         [build-system]
-        requires = ["setuptools>=42", "wheel"]
+        requires = ["setuptools>=42"]
         build-backend = "setuptools.build_meta"
         """
     )


### PR DESCRIPTION
Remove the redundant `wheel` dependency, as it is added by the backend automatically.  Listing it explicitly in the documentation was a historical mistake and has been fixed since, see: https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a